### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group=com.enonic.app
 projectName=xpdoctor
 appName=com.enonic.app.xpdoctor
 xpVersion=8.0.0-B4
-version=2.3.1-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `2.3.1-SNAPSHOT` to `3.0.0-SNAPSHOT` for the XP 8 line on master.
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so the release tooling recognizes both branches.
- Companion PR on `2.x` adds the same workflow config (required because the release action reads `releaseBranch:` from the branch's own workflow file).

The `2.x` maintenance branch was created off commit `37cf10b` ("Updated to next SNAPSHOT version", `version=2.3.0-SNAPSHOT`) — the post-release SNAPSHOT commit following tag `v2.3.0-B3`, not the tag commit itself.

Reference: app-booster's `master` / `1.x` split.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green
- [ ] After companion `2.x` PR merges, a CI run on `2.x` classifies it as a release branch