### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`.
- Required so pushes to `2.x` are recognized as release-branch builds — the release action reads `releaseBranch:` from the branch's own workflow file.
- Workflow-only change. No version bump, no other config changes (per the app-booster `1.x` reference).

Companion to the master PR that bumps to `3.0.0-SNAPSHOT` and adds the same workflow block.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a CI run on `2.x` classifies it as a release branch