### PR TITLE
Migrate to lib-asset #64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:2.18.6"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.6"
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     include xplibs.content
     include xplibs.portal
     include xplibs.node

--- a/src/main/resources/admin/tools/xpdoctor/xpdoctor.html
+++ b/src/main/resources/admin/tools/xpdoctor/xpdoctor.html
@@ -3,31 +3,31 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" type="image/png" data-th-href="${portal.assetUrl({'_path=images/favicon-48x48.png'})}" sizes="32x32">
+    <link rel="icon" type="image/png" data-th-href="${faviconUrl}" sizes="32x32">
     <title>xpDoctor</title>
 
     <!-- reset css -->
-    <link rel="stylesheet" data-th-href="${portal.assetUrl({'_path=css/reset.css'})}"/>
+    <link rel="stylesheet" data-th-href="${resetCssUrl}"/>
 
 
     <!-- app css -->
-    <link rel="stylesheet" data-th-href="${portal.assetUrl({'_path=css/main.css'})}"/>
+    <link rel="stylesheet" data-th-href="${mainCssUrl}"/>
 
     <!--Import Google Icon Font-->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <!-- JQuery -->
-    <script data-th-src="${portal.assetUrl({'_path=js/jquery-3.1.1.min.js'})}"></script>
+    <script data-th-src="${jqueryUrl}"></script>
 
     <!-- Roboto -->
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
 
-    <script type="text/javascript" data-th-src="${portal.assetUrl({'_path=js/renderjson.js'})}"></script>
-    <script data-th-src="${portal.assetUrl({'_path=js/main.js'})}"></script>
+    <script type="text/javascript" data-th-src="${renderJsonUrl}"></script>
+    <script data-th-src="${mainJsUrl}"></script>
 
     <!-- DataTables -->
-    <script data-th-src="${portal.assetUrl({'_path=js/jquery.dataTables.min.js'})}"></script>
-    <link rel="stylesheet" data-th-href="${portal.assetUrl({'_path=css/jquery.dataTables.min.css'})}"></link>
+    <script data-th-src="${dataTablesJsUrl}"></script>
+    <link rel="stylesheet" data-th-href="${dataTablesCssUrl}"></link>
 
     <script data-th-inline="javascript">
         /*<![CDATA[*/
@@ -48,7 +48,7 @@
     <nav class="navbar">
 
         <span class="progress" id="progressState"></span>
-        <a class="navbar-brand" href="#"><img data-th-src="${portal.assetUrl({'_path=images/xpDoc.png'})}"/></a>
+        <a class="navbar-brand" href="#"><img data-th-src="${logoUrl}"/></a>
     </nav>
 
     <div class="mainContainer">

--- a/src/main/resources/admin/tools/xpdoctor/xpdoctor.js
+++ b/src/main/resources/admin/tools/xpdoctor/xpdoctor.js
@@ -1,5 +1,6 @@
 var thymeleaf = require('/lib/thymeleaf');
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var dataValidator = require('/lib/dataValidator.js');
 
 exports.get = function (req) {
@@ -11,7 +12,15 @@ exports.get = function (req) {
 
     var model = {
         validators: createValidatorsModel(),
-        assetsUrl: portal.assetUrl({path: ""}),
+        faviconUrl: assetLib.assetUrl({path: 'images/favicon-48x48.png'}),
+        resetCssUrl: assetLib.assetUrl({path: 'css/reset.css'}),
+        mainCssUrl: assetLib.assetUrl({path: 'css/main.css'}),
+        jqueryUrl: assetLib.assetUrl({path: 'js/jquery-3.1.1.min.js'}),
+        renderJsonUrl: assetLib.assetUrl({path: 'js/renderjson.js'}),
+        mainJsUrl: assetLib.assetUrl({path: 'js/main.js'}),
+        dataTablesJsUrl: assetLib.assetUrl({path: 'js/jquery.dataTables.min.js'}),
+        dataTablesCssUrl: assetLib.assetUrl({path: 'css/jquery.dataTables.min.css'}),
+        logoUrl: assetLib.assetUrl({path: 'images/xpDoc.png'}),
         validatorServiceUrl: getServiceUrl('validator-service'),
         progressServiceUrl: getServiceUrl('progress-service'),
         stateServiceUrl: getServiceUrl('state-service'),

--- a/src/main/resources/admin/tools/xpdoctor/xpdoctor.yaml
+++ b/src/main/resources/admin/tools/xpdoctor/xpdoctor.yaml
@@ -3,3 +3,5 @@ title: "XP-Doctor"
 description: "Analyze and repair data"
 allow:
   - "role:system.admin"
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #64

`portal.assetUrl` (from `/lib/xp/portal`) is deprecated — *"Use libAsset or libStatic instead. This function will be removed in future versions."* This PR migrates the xpdoctor admin tool to `lib-asset`. Admin tools support `lib-asset` directly (vs `lib-static`, which is for admin extensions / id providers / universal APIs).

## What changed

- `build.gradle` — bundles `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT`.
- `src/main/resources/admin/tools/xpdoctor/xpdoctor.yaml` — registers `apis: ["asset"]` on the admin tool so the bundled asset API is mounted under it. Without this, asset URLs would 404 with *"API [com.enonic.app.xpdoctor:asset] is not mounted"*.
- `src/main/resources/admin/tools/xpdoctor/xpdoctor.js` — adds `require('/lib/enonic/asset')`, pre-computes one URL per asset path (`assetLib.assetUrl({path: '...'})`), and removes the unused `assetsUrl: portal.assetUrl({path: ''})` model field (the empty-path idiom was never read by the template). `portal.serviceUrl` calls are kept; `/lib/xp/portal` import stays.
- `src/main/resources/admin/tools/xpdoctor/xpdoctor.html` — nine `${portal.assetUrl({_path=...})}` Thymeleaf calls replaced with `${faviconUrl}`, `${resetCssUrl}`, `${mainCssUrl}`, `${jqueryUrl}`, `${renderJsonUrl}`, `${mainJsUrl}`, `${dataTablesJsUrl}`, `${dataTablesCssUrl}`, `${logoUrl}`.

## Test plan

- [x] Build resources: `./gradlew jar -x compileJava` produces a jar with the updated descriptors and lib-asset classes bundled. (`./gradlew build` fails on master because Java sources still reference `org.elasticsearch.*` packages dropped from XP 8's compile classpath — pre-existing breakage from #58, not caused by this PR.)
- [x] Deployed to a local XP 8.0.0-B4 sandbox in `/tmp`. Bundle reaches ACTIVE.
- [x] Admin tool at `/admin/com.enonic.app.xpdoctor/xpdoctor` renders, with all nine asset references rewritten to the lib-asset format: `/admin/com.enonic.app.xpdoctor/xpdoctor/_/com.enonic.app.xpdoctor:asset/<fingerprint>/<path>`.
- [x] Each of the nine asset URLs returns HTTP 200 with the correct `Content-Type`:
  - `css/main.css` (4817 B, text/css)
  - `css/reset.css` (1130 B, text/css)
  - `css/jquery.dataTables.min.css` (13900 B, text/css)
  - `js/jquery-3.1.1.min.js` (86709 B, application/javascript)
  - `js/renderjson.js` (10892 B, application/javascript)
  - `js/main.js` (12480 B, application/javascript)
  - `js/jquery.dataTables.min.js` (81906 B, application/javascript)
  - `images/favicon-48x48.png` (779 B, image/png)
  - `images/xpDoc.png` (34059 B, image/png)
- [x] `grep -r 'portal\.assetUrl' src/main/resources` returns nothing.

## Note on the broken Java path

Master is in a known-broken build state from the XP 8 upgrade (#58) — `StorageSpyService` and the `validator/nodevalidator/*` tree still call `org.elasticsearch.*` APIs that XP 8 no longer publishes on the compile classpath, and `me.myklebust.xpdoctor.json.ObjectMapperHelper`/`JsonMapGenerator` still import Jackson directly. PR #58's description explicitly lists this as out-of-scope follow-up. This PR doesn't touch that surface; during runtime E2E, the validator backend was stubbed to confirm the rendered HTML and the asset URLs work. Once the Java backend is fixed, the migrated tool will work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)