### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,14 +10,14 @@ java {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     implementation xplibs.api.core
     implementation xplibs.api.portal
     implementation "com.enonic.xp:core-elasticsearch:${xpVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.18.6"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.6"
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    implementation libs.jackson.databind
+    implementation libs.jackson.datatype.jsr310
+    include libs.lib.thymeleaf
+    include libs.lib.asset
     include xplibs.content
     include xplibs.portal
     include xplibs.node

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+jackson = "2.18.6"
+junit = "4.13.2"
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
+junit = { module = "junit:junit", version.ref = "junit" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move every inline dependency version in `build.gradle` into a fresh
`gradle/libs.versions.toml` catalog and reference it through the
`libs.*` accessor. Pin-for-pin — no version bumps.

## Conventions

- Version + library keys are lowercase, hyphen-separated.
- `[versions]` and `[libraries]` sorted alphabetically.
- The two jackson artifacts share a single `jackson` version ref
  since they're released in lockstep.
- `xpVersion` left in `gradle.properties` as a regular Gradle property
  (the rest of the toolchain expects it there).
- `xplibs.*` accessors are untouched — those come from the XP gradle
  plugin and are not a per-repo concern.

## New catalog content

```toml
[versions]
asset = "2.0.0-SNAPSHOT"
jackson = "2.18.6"
junit = "4.13.2"
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
junit = { module = "junit:junit", version.ref = "junit" }
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Verification

`./gradlew dependencies --configuration runtimeClasspath` produces an
identical resolved graph before and after the migration (verified by
diffing the two outputs — only the wall-clock duration line differs).

A full `./gradlew build` currently fails on `master` for an unrelated
reason: XP 8 dropped the public `org.elasticsearch.*` compile classpath
that several `*.java` files under `validator/nodevalidator/` still
import. That break exists with or without this PR — confirmed by
re-running `compileJava` on `master` before this branch was created.
The migration itself is purely a build-script change.

## Test plan
- [x] `./gradlew dependencies --configuration runtimeClasspath` matches
      pre-migration output byte-for-byte (apart from the build-duration
      line).
- [x] Pre-existing `compileJava` failure reproduces on `master` and is
      not introduced by this PR.